### PR TITLE
Alternative of zoom.js

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,6 +20,7 @@ layout: default
       </div>
     </div>
   </div>
+<!-- we can include magnifier.js inside the HTML file only to magnify any text or images, through inline scripting functions of magnifier.js-->
   <div class="container-fluid bottom-content" id="particles-js">
     <div class="row justify-content-md-center">
       <div class="col-md-8 my-5">


### PR DESCRIPTION
Instead of using zoom.js we can use magnifier.js where we can include the code of javascript inline in the HTML.